### PR TITLE
Add auto expand capability to support macros

### DIFF
--- a/src/clouds_aws/remote_stack/aws_client.py
+++ b/src/clouds_aws/remote_stack/aws_client.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 from clouds_aws.local_stack.helpers import dump_json
 
 LOG = logging.getLogger(__name__)
-CAPABILITIES = ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM']
+CAPABILITIES = ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND']
 
 
 class CloudFormationError(Exception):


### PR DESCRIPTION
For extending macros in cloudformation templates it is required to set the auto expand capability. https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html